### PR TITLE
Update proxy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Folder specific
+* @SRE

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://dependabot.com/docs/config-file-beta/validator/
+---
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 defaults:
   run:
     shell: sh
@@ -39,11 +41,14 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    container: wata727/tflint
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Lint
+      - name: Setup
+        uses: terraform-linters/setup-tflint@v1.1.0
+      - name: Show version
+        run: tflint --version
+      - name: Run
         run: >
           find ./modules/ -maxdepth 1 -mindepth 1
           -exec tflint {} --loglevel=info \;
@@ -51,11 +56,14 @@ jobs:
   security:
     name: Security
     runs-on: ubuntu-latest
-    container:
-      image: liamg/tfsec
-      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Security
-        run: /usr/bin/tfsec ./modules --verbose
+      - name: tfsec
+        uses: tfsec/tfsec-sarif-action@master
+        with:
+          sarif_file: tfsec.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: tfsec.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.terraform
+.terraform*
 terraform.tfstate
 *.tfstate*
 terraform.tfvars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,33 @@
 # Change Log
 
+## v1.2.0
+
+All changes are compatible with the previous versions,
+however upgrading an existing deploy will cause downtime.
+This is the recommended upgrade process:
+
+  1. Deploy new module using the same enrollment token from the existing one
+  2. After checking the target groups are all healthy, update the CloudGen Access Proxy Host on the console
+  3. Wait 15-30m to ensure all the clients updated the configuration
+  4. Destroy the previous module
+
+- [aws-asg] Update aws_elasticache_replication_group with new multi_az_enabled parameter
+- [aws-asg] Use Amazon Linux 2 AMI as default AMI
+- [aws-asg] Update naming
+- [aws-asg] Allow multiple deploys on the same region
+- [aws-asg] Allow specifying custom tags
+- [aws-asg] Require terraform 0.14 to allow sensitive variables
+
 ## v1.1.0
 
-- Require terraform 0.13 to allow validations
-- Update README and misc logic
-- Allow using custom AMI
-- Add CloudWatch logs configuration
-- Add Fyde Access Proxy log level configuration
-- Prevent lingering token after module removal
-- Create redis elasticache when instance count is more than 1
-- Recycle instances on launch configuration change
+- [aws-asg] Require terraform 0.13 to allow validations
+- [aws-asg] Update README and misc logic
+- [aws-asg] Allow using custom AMI
+- [aws-asg] Add CloudWatch logs configuration
+- [aws-asg] Add CloudGen Access Proxy log level configuration
+- [aws-asg] Prevent lingering token after module removal
+- [aws-asg] Create redis elasticache when instance count is more than 1
+- [aws-asg] Recycle instances on launch configuration change
 
 ## v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -8,53 +8,14 @@ Visit the [Website](https://www.barracuda.com/products/cloudgen-access)
 
 Check the [Product Documentation](https://campus.barracuda.com/product/cloudgenaccess/doc/93201218/overview/)
 
-## Access Proxy
+## Modules
 
-### AWS - Auto Scaling Group
-
-Usage example:
-
-```yaml
-module "fyde-access-proxy" {
-  source = "git::git@github.com/barracuda-cloudgen-access/terraform-modules.git//modules/aws-asg?ref=v1.1.0"
-
-  # Fyde Access Proxy
-  fyde_access_proxy_public_port = 443
-  fyde_access_proxy_token       = "replace_with_token"
-
-  # AWS
-  aws_region = "us-east-1"
-
-  # Network Load Balancing
-  nlb_subnets = ["subnet-public-1", "subnet-public-2", "subnet-public-3"]
-
-  # Auto Scaling Group
-  asg_desired_capacity    = 3
-  asg_min_size            = 3
-  asg_max_size            = 3
-  asg_subnets             = ["subnet-private-1", "subnet-private-2", "subnet-private-3"]
-
-  # Launch Configuration
-  launch_cfg_instance_type = "t2.small"
-  launch_cfg_key_pair_name = "key_pair_name"
-}
-
-output "Network_Load_Balancer_DNS_Name" {
-  value       = module.fyde-access-proxy.Network_Load_Balancer_DNS_Name
-}
-
-output "Security_Group_for_Resources" {
-  value       = module.fyde-access-proxy.Security_Group_for_Resources
-}
-```
-
-Check all the available variables [here](modules/aws-asg/README.md)
+- [CloudGen Access Proxy ASG](./modules/aws-asg/)
 
 ## Misc
 
 - This repository has [pre-commit](https://github.com/antonbabenko/pre-commit-terraform) configured
   - Test all the pre-commit hooks with `pre-commit run -a`
-- Test branch with `git::git@github.com:fyde/terraform-modules.git//modules/aws-asg?ref=<branch-name>`
 - Test github actions with [nektos/act](https://github.com/nektos/act)
 
 ## Links

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -43,7 +43,7 @@ No modules.
 | [aws_security_group_rule.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [null_resource.redis_multiaz_enable](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.tags_as_list_of_maps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_ami.fyde_access_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_subnet.vpc_from_first_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 

--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -2,16 +2,19 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.26 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3 |
 | <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.26 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3 |
 
 ## Modules
 
@@ -23,13 +26,13 @@ No modules.
 |------|------|
 | [aws_autoscaling_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_notification.notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_notification) | resource |
-| [aws_cloudwatch_log_group.fyde_access_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.cloudgen_access_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_elasticache_replication_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
 | [aws_elasticache_subnet_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_instance_profile.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.cloudgen_access_proxy_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.fyde_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_launch_configuration.launch_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_lb.nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
@@ -41,8 +44,8 @@ No modules.
 | [aws_security_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [null_resource.redis_multiaz_enable](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.tags_as_list_of_maps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_string.prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_ami.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_subnet.vpc_from_first_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -51,28 +54,29 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_ami"></a> [asg\_ami](#input\_asg\_ami) | Defaults to 'fyde' to use the AMI maintained and secured by Fyde.<br>  Suported types are CentOS or AWS Linux based" | `string` | `"fyde"` | no |
+| <a name="input_asg_ami"></a> [asg\_ami](#input\_asg\_ami) | Uses linux AMI maintained by AWS by default.<br>  Suported types are CentOS, Ubuntu or AWS Linux based. | `string` | `"amazonlinux2"` | no |
 | <a name="input_asg_desired_capacity"></a> [asg\_desired\_capacity](#input\_asg\_desired\_capacity) | The number of Amazon EC2 instances that should be running in the auto scaling group | `number` | `3` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | The minimum size of the auto scaling group | `number` | `3` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | The maximum size of the auto scaling group | `number` | `3` | no |
 | <a name="input_asg_notification_arn_topic"></a> [asg\_notification\_arn\_topic](#input\_asg\_notification\_arn\_topic) | Optional ARN topic to get Auto Scaling Group events | `string` | `""` | no |
-| <a name="input_asg_subnets"></a> [asg\_subnets](#input\_asg\_subnets) | A list of subnet IDs to launch resources in.<br>  Use Private Subnets with NAT Gateway configured or Public Subnets | `list` | n/a | yes |
+| <a name="input_asg_subnets"></a> [asg\_subnets](#input\_asg\_subnets) | A list of subnet IDs to launch resources in.<br>  Use Private Subnets with NAT Gateway configured or Public Subnets | `list(any)` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_cloudWatch_logs_retention_in_days"></a> [cloudWatch\_logs\_retention\_in\_days](#input\_cloudWatch\_logs\_retention\_in\_days) | Days to keep CloudWatch logs (Possible values are:<br>    1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>    0 = never delete.) | `number` | `7` | no |
+| <a name="input_cloudgen_access_proxy_level"></a> [cloudgen\_access\_proxy\_level](#input\_cloudgen\_access\_proxy\_level) | Set the CloudGen Access Proxy orchestrator log level | `string` | `"info"` | no |
+| <a name="input_cloudgen_access_proxy_public_port"></a> [cloudgen\_access\_proxy\_public\_port](#input\_cloudgen\_access\_proxy\_public\_port) | Public port for this proxy (must match the value configured in the console for this proxy) | `number` | `443` | no |
+| <a name="input_cloudgen_access_proxy_token"></a> [cloudgen\_access\_proxy\_token](#input\_cloudgen\_access\_proxy\_token) | CloudGen Access Proxy Token for this proxy (obtained from the console after proxy creation) | `string` | n/a | yes |
 | <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Set to true to send '/var/log/message' logs to CloudWatch | `bool` | `true` | no |
-| <a name="input_fyde_access_proxy_public_port"></a> [fyde\_access\_proxy\_public\_port](#input\_fyde\_access\_proxy\_public\_port) | Public port for this proxy (must match the value configured in the console for this proxy) | `number` | `443` | no |
-| <a name="input_fyde_access_proxy_token"></a> [fyde\_access\_proxy\_token](#input\_fyde\_access\_proxy\_token) | Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation) | `any` | n/a | yes |
-| <a name="input_fyde_proxy_level"></a> [fyde\_proxy\_level](#input\_fyde\_proxy\_level) | Set the Fyde Proxy orchestrator log level | `string` | `"info"` | no |
 | <a name="input_launch_cfg_associate_public_ip_address"></a> [launch\_cfg\_associate\_public\_ip\_address](#input\_launch\_cfg\_associate\_public\_ip\_address) | Associate a public ip address with an instance in a VPC | `bool` | `false` | no |
-| <a name="input_launch_cfg_instance_type"></a> [launch\_cfg\_instance\_type](#input\_launch\_cfg\_instance\_type) | The type of instance to use (t2.micro, t2.small, t2.medium, etc) | `string` | `"t2.small"` | no |
+| <a name="input_launch_cfg_instance_type"></a> [launch\_cfg\_instance\_type](#input\_launch\_cfg\_instance\_type) | The type of instance to use (e.g. t2.micro, t2.small, t2.medium, etc) | `string` | `"t2.small"` | no |
 | <a name="input_launch_cfg_key_pair_name"></a> [launch\_cfg\_key\_pair\_name](#input\_launch\_cfg\_key\_pair\_name) | The name of the key pair to use | `string` | n/a | yes |
-| <a name="input_module_version"></a> [module\_version](#input\_module\_version) | Terraform module version | `string` | `"v1.1.0"` | no |
+| <a name="input_module_version"></a> [module\_version](#input\_module\_version) | Terraform module version | `string` | `"v1.2.0"` | no |
 | <a name="input_nlb_enable_cross_zone_load_balancing"></a> [nlb\_enable\_cross\_zone\_load\_balancing](#input\_nlb\_enable\_cross\_zone\_load\_balancing) | Configure cross zone load balancing for the NLB | `bool` | `false` | no |
 | <a name="input_nlb_subnets"></a> [nlb\_subnets](#input\_nlb\_subnets) | A list of public subnet IDs to attach to the LB. Use Public Subnets only | `list(string)` | n/a | yes |
-| <a name="input_redis_subnets"></a> [redis\_subnets](#input\_redis\_subnets) | A list of subnet IDs to to use for the redis instances.<br>  At least two subnets on different Availability Zones must be provided | `list` | `[]` | no |
+| <a name="input_redis_subnets"></a> [redis\_subnets](#input\_redis\_subnets) | A list of subnet IDs to to use for the redis instances.<br>  At least two subnets on different Availability Zones must be provided | `list(any)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_Network_Load_Balancer_DNS_Name"></a> [Network\_Load\_Balancer\_DNS\_Name](#output\_Network\_Load\_Balancer\_DNS\_Name) | Update the Fyde Access Proxy in the Console with this DNS name |
+| <a name="output_Network_Load_Balancer_DNS_Name"></a> [Network\_Load\_Balancer\_DNS\_Name](#output\_Network\_Load\_Balancer\_DNS\_Name) | Update the CloudGen Access Proxy in the Console with this DNS name |

--- a/modules/aws-asg/examples/cga_with_vpc.tf
+++ b/modules/aws-asg/examples/cga_with_vpc.tf
@@ -1,0 +1,146 @@
+#
+# Variables
+#
+
+variable "cloudgen_access_proxy_token" {
+  type      = string
+  sensitive = true
+}
+
+locals {
+  application            = "cloudgen-access-proxy-test"
+  aws_availability_zones = ["a", "b", "c"]
+  aws_region             = "us-east-1"
+  aws_subnet_cidr_block  = "172.16.0.0/23"
+}
+
+provider "aws" {
+  region = local.aws_region
+}
+
+#
+# CloudGen Access Proxy
+#
+
+module "cloudgen-access-proxy" {
+  source = "git::git@github.com:barracuda-cloudgen-access/terraform-modules.git//modules/aws-asg?ref=v1.1.0"
+
+  # More examples
+  # run 'rm -rf .terraform/' after changing source
+  # source = "git::git@github.com:barracuda-cloudgen-access/terraform-modules.git//modules/aws-asg?ref=<branch-name>"
+  # source = "../"
+
+  # CloudGen Access Proxy
+  cloudgen_access_proxy_public_port = 443
+  cloudgen_access_proxy_token       = var.cloudgen_access_proxy_token
+
+  # AWS
+  aws_region = local.aws_region
+
+  # Network Load Balancing
+  nlb_subnets = module.vpc.public_subnets
+
+  # Auto Scaling Group
+  asg_desired_capacity = 3
+  asg_min_size         = 3
+  asg_max_size         = 3
+  asg_subnets          = module.vpc.private_subnets
+
+  # Launch Configuration
+  launch_cfg_instance_type = "t3.small"
+  launch_cfg_key_pair_name = module.key_pair.key_pair_key_name
+
+  tags = {
+    Environment = "test"
+    Team        = "awesome"
+  }
+}
+
+output "Network_Load_Balancer_DNS_Name" {
+  value = module.cloudgen-access-proxy.Network_Load_Balancer_DNS_Name
+}
+
+output "Security_Group_for_Resources" {
+  value = module.cloudgen-access-proxy.Security_Group_for_Resources
+}
+
+#
+# SSH key for instances
+#
+
+# (!) The private key will be saves in the terraform state file
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+module "key_pair" {
+  source  = "terraform-aws-modules/key-pair/aws"
+  version = "1.0.0"
+
+  key_name   = local.application
+  public_key = tls_private_key.private_key.public_key_openssh
+}
+
+#
+# VPC
+#
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.0.0"
+
+  name = local.application
+
+  cidr = local.aws_subnet_cidr_block
+
+  azs = formatlist("${local.aws_region}%s", local.aws_availability_zones)
+
+  private_subnets = [
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 0),
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 1),
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 2)
+  ]
+
+  private_subnet_tags = {
+    Name = "${local.application}-private"
+  }
+
+  public_subnets = [
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 4),
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 5),
+    cidrsubnet(local.aws_subnet_cidr_block, 3, 6)
+  ]
+
+  public_subnet_tags = {
+    Name = "${local.application}-public"
+  }
+
+  enable_ipv6        = false
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  default_network_acl_name       = "${local.application}-default"
+  default_security_group_egress  = []
+  default_security_group_ingress = []
+  default_security_group_name    = "${local.application}-default"
+  manage_default_network_acl     = true
+  manage_default_security_group  = true
+
+  tags = {
+    environment = local.application
+  }
+
+  vpc_tags = {
+    Name = local.application
+  }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = module.vpc.default_route_table_id
+
+  tags = {
+    Name        = "${local.application}-default"
+    environment = local.application
+    warning     = "This is created by AWS for the VPC and cannot be removed"
+  }
+}

--- a/modules/aws-asg/examples/cga_with_vpc.tf
+++ b/modules/aws-asg/examples/cga_with_vpc.tf
@@ -23,7 +23,7 @@ provider "aws" {
 #
 
 module "cloudgen-access-proxy" {
-  source = "git::git@github.com:barracuda-cloudgen-access/terraform-modules.git//modules/aws-asg?ref=v1.1.0"
+  source = "git::git@github.com:barracuda-cloudgen-access/terraform-modules.git//modules/aws-asg?ref=v1.2.0"
 
   # More examples
   # run 'rm -rf .terraform/' after changing source

--- a/modules/aws-asg/locals.tf
+++ b/modules/aws-asg/locals.tf
@@ -6,11 +6,14 @@ locals {
 
   redis_enabled = var.asg_desired_capacity > 1 ? true : false
 
-  common_tags_map = {
-    application      = "fyde-access-proxy"
-    "module_version" = var.module_version
-    "disclaimer"     = "Created by terraform"
-  }
+  common_tags_map = merge(
+    {
+      application      = "cloudgen-access-proxy"
+      "module_version" = var.module_version
+      "disclaimer"     = "Created by terraform"
+    },
+    var.tags
+  )
 
   common_tags_asg = null_resource.tags_as_list_of_maps.*.triggers
 }

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -1,18 +1,32 @@
 #
+# Prefix
+#
+
+resource "random_string" "prefix" {
+  length  = 6
+  lower   = true
+  upper   = true
+  number  = true
+  special = false
+}
+
+#
 # Enrollment token
 #
 
 resource "aws_secretsmanager_secret" "token" {
-  name                    = "fyde_enrollment_token"
-  description             = "Fyde Access Proxy Enrollment Token"
+  name                    = "cga_proxy_${random_string.prefix.result}_enrollment_token"
+  description             = "CloudGen Access Proxy Enrollment Token"
   recovery_window_in_days = 0
 
-  tags = local.common_tags_map
+  tags = {
+    Name = "cga_proxy_${random_string.prefix.result}_enrollment_token"
+  }
 }
 
 resource "aws_secretsmanager_secret_version" "token" {
   secret_id     = aws_secretsmanager_secret.token.id
-  secret_string = var.fyde_access_proxy_token
+  secret_string = var.cloudgen_access_proxy_token
 }
 
 #
@@ -23,24 +37,17 @@ resource "aws_lb" "nlb" {
   enable_cross_zone_load_balancing = var.nlb_enable_cross_zone_load_balancing
   internal                         = false #tfsec:ignore:AWS005
   load_balancer_type               = "network"
-  name_prefix                      = "fyde-"
+  name_prefix                      = "cga-"
   subnets                          = var.nlb_subnets
 
   lifecycle {
     create_before_destroy = true
   }
-
-  tags = merge(
-    {
-      "Name" = "fyde-access-proxy"
-    },
-    local.common_tags_map
-  )
 }
 
 resource "aws_lb_listener" "nlb_listener" {
   load_balancer_arn = aws_lb.nlb.arn
-  port              = var.fyde_access_proxy_public_port
+  port              = var.cloudgen_access_proxy_public_port
   protocol          = "TCP"
 
   lifecycle {
@@ -55,14 +62,14 @@ resource "aws_lb_listener" "nlb_listener" {
 
 resource "aws_lb_target_group" "nlb_target_group" {
   deregistration_delay = 60
-  name_prefix          = "fyde-"
-  port                 = var.fyde_access_proxy_public_port
+  name_prefix          = "cga-"
+  port                 = var.cloudgen_access_proxy_public_port
   protocol             = "TCP"
   vpc_id               = data.aws_subnet.vpc_from_first_subnet.vpc_id
 
   health_check {
     interval          = 30
-    port              = var.fyde_access_proxy_public_port
+    port              = var.cloudgen_access_proxy_public_port
     protocol          = "TCP"
     healthy_threshold = 3
   }
@@ -70,13 +77,6 @@ resource "aws_lb_target_group" "nlb_target_group" {
   lifecycle {
     create_before_destroy = true
   }
-
-  tags = merge(
-    {
-      "Name" = "fyde-access-proxy"
-    },
-    local.common_tags_map
-  )
 }
 
 #
@@ -87,8 +87,8 @@ resource "aws_lb_target_group" "nlb_target_group" {
 # You cannot allow traffic from clients to targets through the load balancer using the security groups for the clients in the security groups for the targets.
 # Use the client CIDR blocks in the target security groups instead.
 resource "aws_security_group" "inbound" {
-  name        = "fyde-access-proxy-inbound"
-  description = "Inbound traffic for Fyde Access Proxy"
+  name        = "cga-proxy-${random_string.prefix.result}-inbound"
+  description = "Inbound traffic for CloudGen Access Proxy"
   vpc_id      = data.aws_subnet.vpc_from_first_subnet.vpc_id
 
   ingress {
@@ -106,45 +106,35 @@ resource "aws_security_group" "inbound" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
   }
 
-  tags = merge(
-    {
-      "Name" = "fyde-access-proxy-inbound"
-    },
-    local.common_tags_map
-  )
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}-inbound"
+  }
 }
 
 resource "aws_security_group" "resources" {
-  name        = "fyde-access-proxy-resources"
-  description = "Use this group to allow Fyde Access Proxy access to internal resources"
+  name        = "cga-proxy-${random_string.prefix.result}-resources"
+  description = "Use this group to allow CloudGen Access Proxy to access internal resources"
   vpc_id      = data.aws_subnet.vpc_from_first_subnet.vpc_id
 
-  tags = merge(
-    {
-      "Name" = "fyde-access-proxy-resources"
-    },
-    local.common_tags_map
-  )
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}-resources"
+  }
 }
 
 resource "aws_security_group" "redis" {
   count = local.redis_enabled ? 1 : 0
 
-  name        = "fyde-access-proxy-redis"
-  description = "Used to allow FydeAccessProxy access to redis"
+  name        = "cga-proxy-${random_string.prefix.result}-redis"
+  description = "Used to allow CloudGen Access proxy to redis"
   vpc_id      = data.aws_subnet.vpc_from_first_subnet.vpc_id
 
-  tags = merge(
-    {
-      "Name" = "fyde-access-proxy-redis"
-    },
-    local.common_tags_map
-  )
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}-redis"
+  }
 }
 
 resource "aws_security_group_rule" "redis" {
   count = local.redis_enabled ? 1 : 0
-
 
   description       = "Allow ingress to redis port from group members"
   type              = "ingress"
@@ -184,11 +174,11 @@ resource "aws_autoscaling_group" "asg" {
     [
       {
         "key"                 = "Name"
-        "value"               = "fyde-access-proxy"
+        "value"               = aws_launch_configuration.launch_config.name
         "propagate_at_launch" = true
       },
     ],
-    local.common_tags_asg,
+    local.common_tags_asg
   )
 }
 
@@ -234,7 +224,7 @@ resource "aws_launch_configuration" "launch_config" {
   image_id                    = coalesce(data.aws_ami.ami[0].id, var.asg_ami)
   instance_type               = var.launch_cfg_instance_type
   key_name                    = var.launch_cfg_key_pair_name
-  name_prefix                 = "fyde-access-proxy-"
+  name_prefix                 = "cga-proxy-${random_string.prefix.result}-"
   security_groups = compact([
     aws_security_group.inbound.id,
     aws_security_group.resources.id,
@@ -245,7 +235,7 @@ resource "aws_launch_configuration" "launch_config" {
   %{~if var.cloudwatch_logs_enabled~}
   # Install CloudWatch Agent
   curl -sL "https://url.fyde.me/config-ec2-cloudwatch-logs" | bash -s -- \
-    -l "/aws/ec2/FydeAccessProxy" \
+    -l "${aws_cloudwatch_log_group.cloudgen_access_proxy[0].name}" \
     -r "${var.aws_region}"
   %{~endif~}
   # Install CloudGen Access Proxy
@@ -256,7 +246,8 @@ resource "aws_launch_configuration" "launch_config" {
     -s "${aws_elasticache_replication_group.redis[0].port}" \
   %{~endif~}
     -p "${var.cloudgen_access_proxy_public_port}" \
-    -l "${var.cloudgen_access_proxy_level}"
+    -l "${var.cloudgen_access_proxy_level}" \
+    -e "FYDE_PREFIX=cga_proxy_${random_string.prefix.result}_"
   # Harden instance and reboot
   curl -sL "https://url.fyde.me/harden-linux" | bash -s --
   shutdown -r now
@@ -298,119 +289,119 @@ resource "aws_autoscaling_notification" "notification" {
 #
 
 resource "aws_iam_instance_profile" "profile" {
-  name = "fyde-access-proxy-profile"
+  name = "cga-proxy-${random_string.prefix.result}-profile"
   role = aws_iam_role.role.name
 }
 
 resource "aws_iam_role" "role" {
-  name        = "fyde-access-proxy-role"
-  description = "Role used for the Fyde Access Proxy instances"
+  name        = "cga-proxy-${random_string.prefix.result}-role"
+  description = "Role used for the CloudGen Access Proxy instances"
   path        = "/"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Sid": "",
-        "Effect": "Allow",
-        "Action": "sts:AssumeRole",
-        "Principal": {
-            "Service": "ec2.amazonaws.com"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AssumeRole"
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "ec2.amazonaws.com"
         }
-    }]
-}
-EOF
+      }
+    ]
+  })
+
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}-role"
+  }
 }
 
-resource "aws_iam_role_policy" "fyde_secrets" {
-  name = "fyde-access-proxy-fyde-secrets"
+resource "aws_iam_role_policy" "cloudgen_access_proxy_secrets" {
+  name = "cga-proxy-${random_string.prefix.result}-secrets"
   role = aws_iam_role.role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "GetFydeSecrets",
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:DescribeSecret",
-        "secretsmanager:GetSecretValue"
-      ],
-      "Resource": "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:fyde_*"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "GetSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:cga_proxy_${random_string.prefix.result}_*"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "cloudwatch_logs" {
   count = var.cloudwatch_logs_enabled ? 1 : 0
 
-  name = "fyde-access-proxy-cloudwatch-logs"
+  name = "cga-proxy-${random_string.prefix.result}-cloudwatch-logs"
   role = aws_iam_role.role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "CloudWatchLogGroup",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "${aws_cloudwatch_log_group.fyde_access_proxy[0].arn}"
-    },
-    {
-      "Sid": "CloudWatchLogStreams",
-      "Effect": "Allow",
-      "Action": [
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "${aws_cloudwatch_log_group.cloudgen_access_proxy[0].arn}:*"
+      },
+      {
+        Sid    = "CloudWatchLogStreams"
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy" "redis" {
   count = local.redis_enabled ? 1 : 0
 
-  name = "fyde-access-proxy-redis"
+  name = "cga-proxy-${random_string.prefix.result}-redis"
   role = aws_iam_role.role.id
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "DiscoverRedisCluster",
-      "Effect": "Allow",
-      "Action": [
-        "elasticache:DescribeCacheClusters"
-      ],
-      "Resource": "arn:aws:elasticache:${var.aws_region}:${data.aws_caller_identity.current.account_id}:replicationgroup:${aws_elasticache_replication_group.redis[0].id}"
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DiscoverRedisCluster"
+        Effect = "Allow"
+        Action = [
+          "elasticache:DescribeCacheClusters"
+        ]
+        Resource = "arn:aws:elasticache:${var.aws_region}:${data.aws_caller_identity.current.account_id}:replicationgroup:${aws_elasticache_replication_group.redis[0].id}"
+      }
+    ]
+  })
 }
 
 #
 # CloudWatch
 #
 
-resource "aws_cloudwatch_log_group" "fyde_access_proxy" {
+resource "aws_cloudwatch_log_group" "cloudgen_access_proxy" {
   count = var.cloudwatch_logs_enabled ? 1 : 0
 
-  name              = "/aws/ec2/FydeAccessProxy"
+  name              = "/aws/ec2/cga-proxy-${random_string.prefix.result}"
   retention_in_days = var.cloudWatch_logs_retention_in_days
 
-  tags = local.common_tags_map
+  tags = {
+    Name = "/aws/ec2/cga-proxy-${random_string.prefix.result}"
+  }
 }
 
 #
@@ -422,8 +413,8 @@ resource "aws_elasticache_replication_group" "redis" {
 
   automatic_failover_enabled    = true
   engine                        = "redis"
-  replication_group_id          = "FydeAccessProxy"
-  replication_group_description = "Redis for Fyde Access Proxy"
+  replication_group_id          = "cga-proxy-${random_string.prefix.result}"
+  replication_group_description = "Redis for CloudGen Access Proxy"
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = 2
   subnet_group_name             = aws_elasticache_subnet_group.redis[0].name
@@ -433,13 +424,19 @@ resource "aws_elasticache_replication_group" "redis" {
   transit_encryption_enabled    = false #tfsec:ignore:AWS036
   multi_az_enabled              = true
 
-  tags = local.common_tags_map
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}"
+  }
 }
 
 resource "aws_elasticache_subnet_group" "redis" {
   count = local.redis_enabled ? 1 : 0
 
-  name        = "FydeAccessProxy"
-  description = "Redis Subnet Group for Fyde Access Proxy"
+  name        = "cga-proxy-${random_string.prefix.result}"
+  description = "Redis Subnet Group for CloudGen Access Proxy"
   subnet_ids  = coalescelist(var.redis_subnets, var.asg_subnets)
+
+  tags = {
+    Name = "cga-proxy-${random_string.prefix.result}"
+  }
 }

--- a/modules/aws-asg/outputs.tf
+++ b/modules/aws-asg/outputs.tf
@@ -1,9 +1,9 @@
 output "Network_Load_Balancer_DNS_Name" {
-  description = "Update the Fyde Access Proxy in the Console with this DNS name"
+  description = "Update the CloudGen Access Proxy in the Console with this DNS name"
   value       = aws_lb.nlb.dns_name
 }
 
 output "Security_Group_for_Resources" {
-  description = "Use this group to allow Fyde Access Proxy access to internal resources"
+  description = "Use this group to allow CloudGen Access Proxy access to internal resources"
   value       = aws_security_group.resources.id
 }

--- a/modules/aws-asg/provider.tf
+++ b/modules/aws-asg/provider.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags_map
+  }
+}

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -19,6 +19,8 @@ variable "fyde_access_proxy_public_port" {
 
 variable "fyde_access_proxy_token" {
   description = "Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation)"
+  type        = string
+  sensitive   = true
 
   validation {
     condition = can(

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -1,43 +1,42 @@
 
 #
-# Fyde Access Proxy
+# CloudGen Access Proxy
 #
 
-variable "fyde_access_proxy_public_port" {
+variable "cloudgen_access_proxy_public_port" {
   description = "Public port for this proxy (must match the value configured in the console for this proxy)"
   type        = number
   default     = 443
 
   validation {
     condition = (
-      var.fyde_access_proxy_public_port >= 1 &&
-      var.fyde_access_proxy_public_port <= 65535
+      var.cloudgen_access_proxy_public_port >= 1 &&
+      var.cloudgen_access_proxy_public_port <= 65535
     )
     error_message = "Public port needs to be >= 1 and <= 65535."
   }
 }
 
-variable "fyde_access_proxy_token" {
-  description = "Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation)"
+variable "cloudgen_access_proxy_token" {
+  description = "CloudGen Access Proxy Token for this proxy (obtained from the console after proxy creation)"
   type        = string
   sensitive   = true
-
   validation {
     condition = can(
       regex("^https://.+[.]fyde[.]com/proxies.+proxy_auth_token.+$",
-      var.fyde_access_proxy_token)
+      var.cloudgen_access_proxy_token)
     )
-    error_message = "Provided Fyde Access Proxy Token doesn't match the expected format."
+    error_message = "Provided CloudGen Access Proxy Token doesn't match the expected format."
   }
 }
 
-variable "fyde_proxy_level" {
-  description = "Set the Fyde Proxy orchestrator log level"
+variable "cloudgen_access_proxy_level" {
+  description = "Set the CloudGen Access Proxy orchestrator log level"
   type        = string
   default     = "info"
 
   validation {
-    condition     = can(regex("^(info|warning|error|critical|debug)$", var.fyde_proxy_level))
+    condition     = can(regex("^(info|warning|error|critical|debug)$", var.cloudgen_access_proxy_level))
     error_message = "AllowedValues: info, warning, error, critical or debug."
   }
 }
@@ -78,15 +77,15 @@ variable "nlb_subnets" {
 
 variable "asg_ami" {
   description = <<EOF
-  Defaults to 'fyde' to use the AMI maintained and secured by Fyde.
-  Suported types are CentOS or AWS Linux based"
+  Uses linux AMI maintained by AWS by default.
+  Suported types are CentOS, Ubuntu or AWS Linux based.
   EOF
   type        = string
-  default     = "fyde"
+  default     = "amazonlinux2"
 
   validation {
-    condition     = can(regex("^(fyde|ami-.+)$", var.asg_ami))
-    error_message = "AllowedValues: fyde or AMI id starting with 'ami-'."
+    condition     = can(regex("^(amazonlinux2|ami-.+)$", var.asg_ami))
+    error_message = "AllowedValues: amazonlinux2 or AMI id starting with 'ami-'."
   }
 }
 
@@ -133,7 +132,7 @@ variable "launch_cfg_associate_public_ip_address" {
 }
 
 variable "launch_cfg_instance_type" {
-  description = "The type of instance to use (t2.micro, t2.small, t2.medium, etc)"
+  description = "The type of instance to use (e.g. t2.micro, t2.small, t2.medium, etc)"
   type        = string
   default     = "t2.small"
 }

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -44,7 +44,7 @@ variable "cloudgen_access_proxy_level" {
 variable "module_version" {
   description = "Terraform module version"
   type        = string
-  default     = "v1.1.0"
+  default     = "v1.2.0"
 }
 
 #

--- a/modules/aws-asg/variables.tf
+++ b/modules/aws-asg/variables.tf
@@ -174,3 +174,13 @@ variable "redis_subnets" {
   type        = list(any)
   default     = []
 }
+
+#
+# Tags
+#
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13"
+  required_version = "~> 0.14"
 
   required_providers {
     aws      = "~> 3.26"

--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     aws      = "~> 3.26"
+    null     = "~> 3"
+    random   = "~> 3"
     template = "~> 2"
   }
-}
-
-provider "aws" {
-  region = var.aws_region
 }

--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.13"
 
   required_providers {
-    aws      = "~> 2"
+    aws      = "~> 3.26"
     template = "~> 2"
   }
 }


### PR DESCRIPTION
- Update aws_elasticache_replication_group with new multi_az_enabled parameter
- Use Amazon Linux 2 AMI
- Require terraform 0.14 to allow sensitive variables
- Update naming and allow multiple deploys on the same region
- Create full deploy example
- Allow specifying custom tags
- Update to v1.2.0
- Add CODEOWNERS
- Add dependabot configuration
- Update github actions

Deployed and tested successfully.