### PR TITLE
Lock aws provider version

### DIFF
--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = ">= 3.50"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
AWS provider for terraform 4.x is still too new.