### PR TITLE
Bump AWS provider required version

### DIFF
--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.23 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.46.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.23 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3 |
 
 ## Modules
 

--- a/modules/aws-asg/versions.tf
+++ b/modules/aws-asg/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.50"
+      version = ">= 4.23"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Summary
Change aws required_providers version from >= 3.50 to >= 4.23

## Description
The aws_elasticache_replication_group resource uses `description` and `num_cache_clusters` args for all new provider versions since 4.23. See https://registry.terraform.io/providers/hashicorp/aws/4.23.0/docs/resources/elasticache_replication_group. Prior to this there were mised uses of `number_cache_clusters` and `replication_group_description`.  Even though the version requirement was`version = ">= 3.50"`, it seems the module was built and tested w/ `4.46`. 

## Type of change
- Bug fix

## How Has This Been Tested?
I'm in the process of testing rollout of some cga proxies w/ our IT team. 

Theses changes have been tested in:

- [x] Local environment
- [x] Development environment
- [ ] Staging environment
- [ ] Production environment

# Checklist

- [x] Fill the description
- [x] Declare the type of changes included in the pull request
- [x] Describe how has this been tested
- [ ] Add categorical labels (feature/fix/chore/docs/skip-changelog)
- [ ] Add semver labels (patch/minor/major/skip-semver)
