### PR TITLE
Use the graviton t4 series for elasticache

### DIFF
--- a/modules/aws-asg/README.md
+++ b/modules/aws-asg/README.md
@@ -11,8 +11,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.46.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.11.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/modules/aws-asg/main.tf
+++ b/modules/aws-asg/main.tf
@@ -462,7 +462,7 @@ resource "aws_elasticache_replication_group" "redis" {
   engine                     = "redis"
   replication_group_id       = "cga-proxy-${random_string.prefix.result}"
   description                = "Redis for CloudGen Access Proxy"
-  node_type                  = "cache.t2.micro"
+  node_type                  = "cache.t4g.micro"
   num_cache_clusters         = 2
   subnet_group_name          = aws_elasticache_subnet_group.redis[0].name
   security_group_ids         = [aws_security_group.redis[0].id]


### PR DESCRIPTION
# Summary
Use the graviton t4 series for elasticache

## Description
Use the graviton t4 series for elasticache which are more cost-effective, performant, and can be reserved

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Locally

Theses changes have been tested in:

- [x] Local environment
- [ ] Development environment
- [ ] Staging environment
- [ ] Production environment
- No testing required

# Checklist

- [x] Fill the description
- [x] Declare the type of changes included in the pull request
- [x] Describe how has this been tested
- [ ] Add categorical labels (feature/fix/chore/docs/skip-changelog)
- [ ] Add semver labels (patch/minor/major/skip-semver)
