### PR TITLE
chore(ci): disable tfsec steps due to trivy supply chain compromise

### DIFF
--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: tfsec
-        uses: tfsec/tfsec-sarif-action@master
+      # Disabled 2026-03-23: tfsec uses aquasecurity/trivy which was subject to a supply chain compromise
+      # - name: tfsec
+      #   uses: tfsec/tfsec-sarif-action@master
 
       - name: Terraform min/max versions
         id: minMax

--- a/.github/workflows/terraform-security.yml
+++ b/.github/workflows/terraform-security.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   security:
+    # Disabled 2026-03-23: tfsec uses aquasecurity/trivy which was subject to a supply chain compromise
+    if: false
     name: Security
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Summary
tfsec depends on aquasecurity/trivy which was involved in a supply chain compromise. Disabling all tfsec references in CI workflows as an immediate mitigation until a safe replacement can be evaluated (tracked in PLAT-2057).

## Description
- terraform-security.yml: added `if: false` to security job
- terraform-checks.yml: commented out tfsec step in preCommitMinVersions job

## Type of change
<!-- These are only examples you can change these however it fits -->
- Chore (tool, configuration, CI changes, or anything that doesn't reflect on the user)


## How Has This Been Tested?

Theses changes have been tested in:
- No testing required

# Checklist


- [x] Fill the description
- [x] Declare the type of changes included in the pull request
- [x] Describe how has this been tested
- [x] Add categorical labels (feature/fix/chore/docs/skip-changelog)
- [ ] Add semver labels (patch/minor/major/skip-semver)
