### PR TITLE
chore(security): bake algif_aead blacklist into cga-proxy userData (CVE-2026-31431)

### DIFF
--- a/modules/aws-asg/templates/userdata.sh.tpl
+++ b/modules/aws-asg/templates/userdata.sh.tpl
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# CVE-2026-31431 mitigation: blacklist algif_aead kernel module
+echo "blacklist algif_aead" > /etc/modprobe.d/disable-algif.conf
+rmmod algif_aead 2>/dev/null || true
+
 %{if cloudwatch_logs_enabled~}
 
 # Install CloudWatch Agent


### PR DESCRIPTION
## Summary

Permanently bakes the \`algif_aead\` kernel module blacklist into the cga-proxy EC2 instance userData so the CVE-2026-31431 (CopyFail) mitigation persists across instance replacements. The script already ends with \`shutdown -r now\` (via the harden-linux step), so the blacklist is in effect by the time the instance is fully up.

## Changes

- Prepends three lines immediately after the shebang in \`modules/aws-asg/templates/userdata.sh.tpl\`:
  - Write \`/etc/modprobe.d/disable-algif.conf\` to blacklist \`algif_aead\` permanently
  - Unload the module immediately if currently loaded (\`rmmod\`, tolerates not-loaded)

## Test Plan

- [ ] New cga-proxy instance boots and \`/etc/modprobe.d/disable-algif.conf\` exists with correct content
- [ ] \`lsmod | grep algif_aead\` returns empty on new instances
- [ ] Existing proxy functionality unaffected (CloudWatch agent install, proxy install, hardening, reboot)

## Related

CVE-2026-31431 (CopyFail) — algif_aead kernel module blacklist