### PR TITLE
security: add DirtyFrag blacklist to proxy userData (CVE-2026-43284/CVE-2026-43500)

### DIFF
--- a/modules/aws-asg/templates/userdata.sh.tpl
+++ b/modules/aws-asg/templates/userdata.sh.tpl
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 # CVE-2026-31431 mitigation: blacklist algif_aead kernel module
-echo "blacklist algif_aead" > /etc/modprobe.d/disable-algif.conf
+# CVE-2026-43284/CVE-2026-43500 (DirtyFrag) mitigation: blacklist esp4, esp6, rxrpc
+printf 'blacklist algif_aead\ninstall esp4 /bin/false\ninstall esp6 /bin/false\ninstall rxrpc /bin/false\n' > /etc/modprobe.d/cve-blacklist.conf
 rmmod algif_aead 2>/dev/null || true
+rmmod esp4 esp6 rxrpc 2>/dev/null || true
+echo 3 > /proc/sys/vm/drop_caches
 
 %{if cloudwatch_logs_enabled~}
 


### PR DESCRIPTION
## Summary

Adds `esp4`, `esp6`, `rxrpc` kernel module blacklist to the cga-proxy ASG userData, mitigating **DirtyFrag** (CVE-2026-43284 + CVE-2026-43500).

Follows the same pattern as #46 (CVE-2026-31431 CopyFail algif_aead fix).

## Changes

- `modules/aws-asg/templates/userdata.sh.tpl`
  - Consolidated `disable-algif.conf` → `cve-blacklist.conf`
  - Added `install esp4/esp6/rxrpc /bin/false` + `rmmod` + `drop_caches`

## Tracking

PLAT-2631 | BNCGA-6407